### PR TITLE
支持生成 map 文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,3 @@ protoc --markdown_out=. hello.proto
 # set path prefix to /api
 protoc --markdown_out=path_prefix=/api:. hello.proto
 ```
-
-## todo
-- [ ] support enum
-- [ ] support nested message

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ protoc --markdown_out=. hello.proto
 # set path prefix to /api
 protoc --markdown_out=path_prefix=/api:. hello.proto
 ```
+
+## todo
+- [ ] support enum
+- [ ] support nested message

--- a/generator.go
+++ b/generator.go
@@ -196,26 +196,31 @@ func (t *twirp) scanService(d *protokit.ServiceDescriptor) {
 }
 
 func getType(t string) string {
-	if strings.HasPrefix(t, ".") {
+	switch t {
+	case "TYPE_STRING":
+		return "string"
+	case "TYPE_DOUBLE", "TYPE_FLOAT":
+		return "float"
+	case "TYPE_BOOL":
+		return "bool"
+	case "TYPE_INT64", "TYPE_UINT64", "TYPE_INT32", "TYPE_UINT32":
+		return "int"
+	default:
 		return t
 	}
-
-	t = strings.Split(t, "_")[1]
-	return strings.ToLower(t)
 }
 
 func getTypeValue(t string) string {
-	if t == "TYPE_STRING" {
+	switch t {
+	case "TYPE_STRING":
 		return ""
-	} else if t == "TYPE_DOUBLE" || t == "TYPE_FLOAT" {
+	case "TYPE_DOUBLE", "TYPE_FLOAT":
 		return "0.0"
-	} else if t == "TYPE_BOOL" {
+	case "TYPE_BOOL":
 		return "false"
-	} else if t == "TYPE_INT64" || t == "TYPE_UINT64" {
-		return "string<int64>"
-	} else if t == "TYPE_INT32" || t == "TYPE_UINT32" {
+	case "TYPE_INT64", "TYPE_UINT64", "TYPE_INT32", "TYPE_UINT32":
 		return "0"
-	} else {
+	default:
 		return ""
 	}
 }
@@ -285,13 +290,13 @@ func (t *twirp) generateJsDocForField(field field) string {
 		m := t.messages[field.Type[1:]]
 		v = t.generateJsDocForMessage(m)
 		if field.isRepeated() {
-			doc := "// type:<list>"
+			doc := fmt.Sprintf("// type:<list<%s>>", m.Name)
 			if field.Note != "" {
 				doc = " " + field.Note
 			}
 			v = "[" + doc + "\n" + v + "]"
 		} else if field.KeyType != "" {
-			doc := fmt.Sprintf("// type:<map<%s,*>>", getType(field.KeyType))
+			doc := fmt.Sprintf("// type:<map<%s,%s>>", getType(field.KeyType), m.Name)
 			if field.Note != "" {
 				doc = " " + field.Note
 			}

--- a/generator.go
+++ b/generator.go
@@ -93,6 +93,16 @@ func (t *twirp) GenerateMarkdown(req *plugin.CodeGeneratorRequest, resp *plugin.
 
 func (t *twirp) scanMessages(d *protokit.FileDescriptor) {
 	for _, md := range d.GetMessages() {
+		t.scanMessage(md)
+	}
+}
+
+func (t *twirp) scanMessage(md *protokit.Descriptor) {
+	for _, smd := range md.GetMessages() {
+		t.scanMessage(smd)
+	}
+
+	{
 		fields := make([]field, len(md.GetMessageFields()))
 
 		maps := make(map[string]*descriptor.DescriptorProto)

--- a/main.go
+++ b/main.go
@@ -11,6 +11,10 @@ import (
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 )
 
+func init() {
+	log.SetOutput(os.Stderr)
+}
+
 func main() {
 	req := readGenRequest(os.Stdin)
 


### PR DESCRIPTION
对于如下 proto 消息：
```proto
message Point {
    int32 x = 1;
    int32 y = 2;
}
message Line {
    map<int32, Point> a = 1;
}
message HelloResp {
    map<string, int32> kv = 1;
    map<int32, string> kv2 = 2;
    int32 i = 3;
    map<int32, Line> kv3 = 4;
    repeated Point points = 5;
}
```
生成的文档效果如下：
```javascript
{
    kv: {
        "": 0
    }, // type:<map<string,int>>
    kv2: {
        "0": ""
    }, // type:<map<int,string>>
    i: 0, // type:<int>
    kv3: { // type:<map<int,Line>>
        "0": {
            a: { // type:<map<int,Point>>
                "0": {
                    x: 0, // type:<int>
                    y: 0, // type:<int>
                }
            },
        }
    },
    points: [ // type:<list<Point>>
        {
            x: 0, // type:<int>
            y: 0, // type:<int>
        }
    ],
}
```